### PR TITLE
deleted unused message import

### DIFF
--- a/scripts/detection_tracking.py
+++ b/scripts/detection_tracking.py
@@ -46,8 +46,6 @@ import caffe
 from fast_rcnn.test import im_detect
 
 from hospital_people_detector.msg import Proposals_msg
-from hospital_people_detector.msg import Coordinates_msg
-
 from hospital_people_detector.msg import Bbox
 from hospital_people_detector.msg import Single_detection
 from hospital_people_detector.msg import Detections


### PR DESCRIPTION
People detector crashes because it cannot find the message definition.